### PR TITLE
Fix repeated listener registration in useToast

### DIFF
--- a/front/src/hooks/use-toast.ts
+++ b/front/src/hooks/use-toast.ts
@@ -182,7 +182,10 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // The listener should only be registered once on mount and cleaned up on
+    // unmount. "setState" is stable, so an empty dependency array is correct
+    // here and prevents unnecessary add/remove cycles.
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- optimize effect cleanup in `useToast` hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f54d3c1448331926b3888af734090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance of toast notifications by ensuring event listeners are registered only once, preventing unnecessary repeated setup and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->